### PR TITLE
fix `unexpected token '{'` errors @ `plugin-recaptcha` when using `esbuild`.

### DIFF
--- a/packages/puppeteer-extra-plugin-recaptcha/src/index.ts
+++ b/packages/puppeteer-extra-plugin-recaptcha/src/index.ts
@@ -72,6 +72,11 @@ export class PuppeteerExtraPluginRecaptcha extends PuppeteerExtraPlugin {
       scriptSource = HcaptchaContentScript.toString()
       scriptName = 'HcaptchaContentScript'
     }
+    // Some bundlers transform classes to anonymous classes that are assigned to
+    // vars (e.g. esbuild). In such cases, `unexpected token '{'` errors are thrown
+    // once the script is executed. Let's bring class name back to script in such
+    // cases!
+    scriptSource = scriptSource.replace(/class \{/, `class ${scriptName} {`)
     return `(async() => {
       const DATA = ${JSON.stringify(data || null)}
       const OPTS = ${JSON.stringify(this.contentScriptOpts)}


### PR DESCRIPTION
This one was a real pain in the *@#^@ to debug and fix.
But now the sun can shine once again, and the scraping can continue!

Basically, was having a blast running `plugin-recaptcha` locally with `ts-node`, and once the same code hit production aws lambdas it started throwing the mentioned error.

Long story short, it was esbuild and the way it transformed `RecaptchaContentScript` & `HcaptchaContentScript` classes into something like `var HcaptchaContentScript = class {`.

The fix basically looks for such a sequence and injects the class name back.